### PR TITLE
replace size_t i with ssize_t `size_t i` will never be less than 0

### DIFF
--- a/cord.h
+++ b/cord.h
@@ -325,7 +325,7 @@ CORDDEF void cord_pad_start(cordString* str, char c, size_t count)
     if (len + count + 1 >= CORD_STRING_CAP(*str))
         *str = cord_realloc_string(str, (len + count + 1));
 
-    for (size_t i = len - 1; i >= 0; i--)
+    for (ssize_t i = len - 1; i >= 0; i--)
     {
         (*str)[i + count] = (*str)[i];
     }


### PR DESCRIPTION
This was my mistake, when I was replacing the uses of int with `size_t` I didn't notice that this index should be signed. 

This is the only case where the index is expected to be singed.